### PR TITLE
Fix #11 & #12

### DIFF
--- a/src/tree.jl
+++ b/src/tree.jl
@@ -16,7 +16,6 @@ struct SARSOPTree
     Qa_lower::Vector{Vector{Float64}}
 
     ba_children::Vector{UnitRange{Int}} # [ba_idx][o_idx] => bp_idx
-    ba_action::Vector{Int}
     poba::Vector{Vector{Float64}} # [ba_idx][o_idx] => p(o|ba)
 
     _discount::Float64
@@ -54,7 +53,6 @@ function SARSOPTree(solver, pomdp::POMDP)
         Vector{Float64}[],
         Vector{Float64}[],
         Vector{Int}[],
-        Int[],
         Vector{Float64}[],
         discount(pomdp),
         BitVector(),
@@ -156,7 +154,6 @@ function add_action!(tree::SARSOPTree, b_idx::Int, a::Int)
     ba_idx = length(tree.ba_children) + 1
     push!(tree.ba_children, NO_CHILDREN)
     push!(tree.ba_pruned, true)
-    push!(tree.ba_action, a)
     return ba_idx
 end
 

--- a/test/tree.jl
+++ b/test/tree.jl
@@ -40,7 +40,6 @@
         @test length(tree.V_lower) == n_b
         @test length(tree.Qa_upper) == n_b
         @test length(tree.Qa_lower) == n_b
-        @test length(tree.ba_action) == n_ba
         @test length(tree.poba) == n_ba
         @test length(tree.b_pruned) == n_b
         @test length(tree.ba_pruned) == n_ba
@@ -80,7 +79,7 @@
         JSOP.fill_belief!(tree, b_idx)
         Q̲, Q̄, ap_idx = JSOP.max_r_and_q(tree, b_idx)
         ba_idx = tree.b_children[b_idx][ap_idx]
-        a′ = tree.ba_action[ba_idx]
+        a′ = ap_idx
         Rba′ = JSOP.belief_reward(tree, tree.b[b_idx], a′)
         L′ = max(L, Q̲)
         U′ = max(U, Q̲ + γ^(-t)*ϵ)


### PR DESCRIPTION
- Add new `NativeSARSOP.solve_info` that returns the policy as well as an info NamedTuple containing the tree, total planning time, and the total number of planning iterations.
- Remove unnecessary `ba_action` field from the tree. This is leftover from when raw POMDP inputs were used for planning instead of the SparseTabular form we use now.